### PR TITLE
[SDPA-4314] Added re-order children permission for editor, approver & site_admin roles.

### DIFF
--- a/tide_publication.install
+++ b/tide_publication.install
@@ -30,6 +30,22 @@ function tide_publication_install() {
     }
   }
 
+  // Add re-order children permission for roles.
+  if (\Drupal::moduleHandler()->moduleExists('entity_hierarchy')) {
+    $roles = [
+      'approver',
+      'editor',
+      'site_admin',
+    ];
+    foreach ($roles as $role) {
+      $load_role = Role::load($role);
+      if ($load_role) {
+        $role->grantPermission('reorder entity_hierarchy children');
+        $role->save();
+      }
+    }
+  }
+
   _tide_publication_update_search_api_index();
 }
 
@@ -280,7 +296,7 @@ function tide_publication_update_8005() {
 /**
  * Add re-order children permission for roles.
  */
-function tide_core_update_8006() {
+function tide_publication_update_8006() {
   if (\Drupal::moduleHandler()->moduleExists('entity_hierarchy')) {
     $roles = [
       'approver',

--- a/tide_publication.install
+++ b/tide_publication.install
@@ -9,6 +9,7 @@ use Drupal\field\Entity\FieldConfig;
 use Drupal\field\Entity\FieldStorageConfig;
 use Drupal\search_api\Item\Field;
 use Drupal\workflows\Entity\Workflow;
+use Drupal\user\Entity\Role;
 
 /**
  * Implements hook_install().

--- a/tide_publication.install
+++ b/tide_publication.install
@@ -48,6 +48,37 @@ function tide_publication_install() {
   }
 
   _tide_publication_update_search_api_index();
+
+  // Enable entity type/bundles for use with scheduled transitions.
+  if (\Drupal::moduleHandler()->moduleExists('scheduled_transitions')) {
+    $config_factory = \Drupal::configFactory();
+    $config = $config_factory->getEditable('scheduled_transitions.settings');
+    $bundles = $config->get('bundles');
+    if ($bundles) {
+      foreach ($bundles as $bundle) {
+        $enabled_bundles[] = $bundle['bundle'];
+      }
+      if (!in_array('publication', $enabled_bundles)) {
+        $bundles[] = ['entity_type' => 'node', 'bundle' => 'publication'];
+        $config->set('bundles', $bundles)->save();
+      }
+      if (!in_array('publication_page', $enabled_bundles)) {
+        $bundles[] = ['entity_type' => 'node', 'bundle' => 'publication_page'];
+        $config->set('bundles', $bundles)->save();
+      }
+    }
+    else {
+      $publication_bundles = [
+        'publication',
+        'publication_page',
+      ];
+      foreach ($publication_bundles as $bundle) {
+        $bundles[] = ['entity_type' => 'node', 'bundle' => $bundle];
+        $config->set('bundles', $bundles);
+      }
+      $config->save();
+    }
+  }
 }
 
 /**

--- a/tide_publication.install
+++ b/tide_publication.install
@@ -276,3 +276,23 @@ function tide_publication_update_8005() {
   $config->set('cardinality', -1);
   $config->save();
 }
+
+/**
+ * Add re-order children permission for roles.
+ */
+function tide_core_update_8006() {
+  if (\Drupal::moduleHandler()->moduleExists('entity_hierarchy')) {
+    $roles = [
+      'approver',
+      'editor',
+      'site_admin',
+    ];
+    foreach ($roles as $role) {
+      $load_role = Role::load($role);
+      if ($load_role) {
+        $role->grantPermission('reorder entity_hierarchy children');
+        $role->save();
+      }
+    }
+  }
+}

--- a/tide_publication.install
+++ b/tide_publication.install
@@ -38,9 +38,9 @@ function tide_publication_install() {
       'editor',
       'site_admin',
     ];
-    foreach ($roles as $role) {
-      $load_role = Role::load($role);
-      if ($load_role) {
+    foreach ($roles as $role_name) {
+      $role = Role::load($role_name);
+      if ($role) {
         $role->grantPermission('reorder entity_hierarchy children');
         $role->save();
       }
@@ -304,9 +304,9 @@ function tide_publication_update_8006() {
       'editor',
       'site_admin',
     ];
-    foreach ($roles as $role) {
-      $load_role = Role::load($role);
-      if ($load_role) {
+    foreach ($roles as $role_name) {
+      $role = Role::load($role_name);
+      if ($role) {
         $role->grantPermission('reorder entity_hierarchy children');
         $role->save();
       }

--- a/tide_publication.install
+++ b/tide_publication.install
@@ -313,3 +313,38 @@ function tide_publication_update_8006() {
     }
   }
 }
+
+/**
+ * Enable entity type/bundles for use with scheduled transitions.
+ */
+function tide_publication_update_8007() {
+  if (\Drupal::moduleHandler()->moduleExists('scheduled_transitions')) {
+    $config_factory = \Drupal::configFactory();
+    $config = $config_factory->getEditable('scheduled_transitions.settings');
+    $bundles = $config->get('bundles');
+    if ($bundles) {
+      foreach ($bundles as $bundle) {
+        $enabled_bundles[] = $bundle['bundle'];
+      }
+      if (!in_array('publication', $enabled_bundles)) {
+        $bundles[] = ['entity_type' => 'node', 'bundle' => 'publication'];
+        $config->set('bundles', $bundles)->save();
+      }
+      if (!in_array('publication_page', $enabled_bundles)) {
+        $bundles[] = ['entity_type' => 'node', 'bundle' => 'publication_page'];
+        $config->set('bundles', $bundles)->save();
+      }
+    }
+    else {
+      $publication_bundles = [
+        'publication',
+        'publication_page',
+      ];
+      foreach ($publication_bundles as $bundle) {
+        $bundles[] = ['entity_type' => 'node', 'bundle' => $bundle];
+        $config->set('bundles', $bundles);
+      }
+      $config->save();
+    }
+  }
+}


### PR DESCRIPTION
### Jira
https://digital-engagement.atlassian.net/browse/SDPA-4314
Parent ticket - https://digital-engagement.atlassian.net/browse/SDPA-4313
Sub task - https://digital-engagement.atlassian.net/browse/SDPA-4365
### Changes
1. Added "reorder entity_hierarchy children" permission for editor, approver & site_admin roles.
2. Added update hook to enable schedule transitions for tide_publication.