### PR TITLE
[SDPA-4373] Fixes field’s prefilling issue

### DIFF
--- a/tide_publication.module
+++ b/tide_publication.module
@@ -211,24 +211,30 @@ function tide_publication_tide_entity_reference_site_enhancer_transform_alter(&$
  * Implements hook_form_alter().
  */
 function tide_publication_form_alter(&$form, FormStateInterface $form_state, $form_id) {
-  if (\Drupal::routeMatch()->getRouteName() == 'entity.node.entity_hierarchy_reorder' && $current_node = \Drupal::routeMatch()->getParameter('node')) {
-    $destination = ['destination' => "/node/{$current_node->id()}/children"];
+  if (\Drupal::routeMatch()->getRouteName() == 'entity.node.entity_hierarchy_reorder') {
     // Updates the destination of 'Create new Publication page' link
     // under /node/{node_id}/children page.
     if (isset($form['actions']['add_child']['#url']) && $form['actions']['add_child']['#url'] instanceof Url) {
-      $form['actions']['add_child']['#url']->setOption('query', $destination);
-    }
-    array_walk($form['children'], function ($item, $index) use ($destination) {
-      if (is_numeric($index)) {
-        // Updates the destination of the 'edit' link.
-        if (isset($item['operations']['#links']['edit']['url']) && $item['operations']['#links']['edit']['url'] instanceof Url) {
-          $item['operations']['#links']['edit']['url']->setOption('query', $destination);
-        }
-        // Updates the destination of the 'delete' link.
-        if (isset($item['operations']['#links']['delete']['url']) && $item['operations']['#links']['delete']['url'] instanceof Url) {
-          $item['operations']['#links']['delete']['url']->setOption('query', $destination);
-        }
+      /** @var \Drupal\Core\Url $url */
+      $url = $form['actions']['add_child']['#url'];
+      $options = $url->getOptions();
+      if (isset($options['query'][Root::PUBLICATION_FIELD_NAME]) && !empty($options['query'][Root::PUBLICATION_FIELD_NAME])) {
+        $destination_option = ['destination' => "/node/{$options['query'][Root::PUBLICATION_FIELD_NAME]}/children"];
+        $options = array_merge($options['query'], $destination_option);
+        $url->setOption('query', $options);
+        array_walk($form['children'], function ($item, $index) use ($destination_option) {
+          if (is_numeric($index)) {
+            // Updates the destination of the 'edit' link.
+            if (isset($item['operations']['#links']['edit']['url']) && $item['operations']['#links']['edit']['url'] instanceof Url) {
+              $item['operations']['#links']['edit']['url']->setOption('query', $destination_option);
+            }
+            // Updates the destination of the 'delete' link.
+            if (isset($item['operations']['#links']['delete']['url']) && $item['operations']['#links']['delete']['url'] instanceof Url) {
+              $item['operations']['#links']['delete']['url']->setOption('query', $destination_option);
+            }
+          }
+        });
       }
-    });
+    }
   }
 }


### PR DESCRIPTION
### Jira
https://digital-engagement.atlassian.net/browse/SDPA-4373

### Issue
- 'Publication /Parent page' text field does NOT default with the publication parent title.
- the `PUBLICATION_FIELD_NAME` query parameter was override by `destination` parameter.

### Change
Change the code to make two query parameters exist together . 

https://github.com/dpc-sdp/content-vic-gov-au/pull/881