### PR TITLE
[SW-136] change publication authors widget

### DIFF
--- a/config/install/core.entity_form_display.node.publication.default.yml
+++ b/config/install/core.entity_form_display.node.publication.default.yml
@@ -266,7 +266,7 @@ content:
       size: 60
       placeholder: ''
     third_party_settings: {  }
-    type: string_textfield
+    type: entity_reference_autocomplete
     region: content
   field_publication_date:
     weight: 4

--- a/tide_publication.install
+++ b/tide_publication.install
@@ -379,3 +379,24 @@ function tide_publication_update_8007() {
     }
   }
 }
+
+/**
+ * Widget change.
+ *
+ * Changes the field_publication_authors widget to
+ * entity_reference_autocomplete_tags type.
+ */
+function tide_publication_update_8008() {
+  /** @var \Drupal\Core\Entity\Display\EntityFormDisplayInterface $entity_form_display */
+  $entity_form_display = \Drupal::entityTypeManager()
+    ->getStorage('entity_form_display')
+    ->load('node.publication.default');
+  if ($entity_form_display) {
+    $settings = $entity_form_display->getComponent('field_publication_authors');
+    if (isset($settings['type']) && $settings['type'] != 'entity_reference_autocomplete') {
+      $settings['type'] = 'entity_reference_autocomplete';
+      $entity_form_display->setComponent('field_publication_authors', $settings);
+      $entity_form_display->save();
+    }
+  }
+}


### PR DESCRIPTION
### Jira
https://digital-engagement.atlassian.net/browse/SW-136

### Issue
1. `field_publication_authors` widget should be `entity_reference_autocomplete` type.


https://github.com/dpc-sdp/content-solar-vic-gov-au/pull/49