### PR TITLE
[SDPSUP-1754] Add permission for site admin in tide publication

### DIFF
--- a/tests/behat/features/access.feature
+++ b/tests/behat/features/access.feature
@@ -13,6 +13,7 @@ Feature: Access to Publication content type
       | role               | response |
       | authenticated user | 404      |
       | administrator      | 200      |
+      | site_admin         | 200      |
       | editor             | 200      |
       | approver           | 200      |
       | previewer          | 404      |
@@ -27,6 +28,7 @@ Feature: Access to Publication content type
       | role               | response |
       | authenticated user | 404      |
       | administrator      | 200      |
+      | site_admin         | 200      |
       | editor             | 200      |
       | approver           | 200      |
       | previewer          | 404      |

--- a/tide_publication.module
+++ b/tide_publication.module
@@ -28,7 +28,7 @@ function tide_publication_entity_bundle_create($entity_type_id, $bundle) {
   if ($entity_type_id == 'node' && in_array($bundle, ['publication', 'publication_page'])) {
     // Grant permissions on Publication and Publication Page content types to
     // Approver and Editor.
-    $roles = ['approver', 'editor'];
+    $roles = ['approver', 'editor', 'site_admin'];
     $permissions = [
       'create publication content',
       'delete any publication content',


### PR DESCRIPTION
### Jira
https://digital-engagement.atlassian.net/browse/SDPSUP-1754

### Changes
1. Updated `hook_entity_bundle_create()` to allow site_admin for publication operations.
2. Added behat test for site_role.
