### PR TITLE
[SDPA-4582] Added new display heading field and updated show table of…

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
   "type": "drupal-module",
   "license": "GPL-2.0-or-later",
   "require": {
-    "dpc-sdp/tide_core": "^1.5.4",
+    "dpc-sdp/tide_core": "dev-feature/SDPA-4582-display-h3-headings as 1.6.9",
     "dpc-sdp/tide_landing_page": "^1.2.1",
     "drupal/entity_hierarchy": "~2.0"
   },

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
   "type": "drupal-module",
   "license": "GPL-2.0-or-later",
   "require": {
-    "dpc-sdp/tide_core": "dev-feature/SDPA-4582-display-h3-headings as 1.6.9",
+    "dpc-sdp/tide_core": "^1.6.11",
     "dpc-sdp/tide_landing_page": "^1.2.1",
     "drupal/entity_hierarchy": "~2.0"
   },

--- a/config/install/core.entity_form_display.node.publication.default.yml
+++ b/config/install/core.entity_form_display.node.publication.default.yml
@@ -185,7 +185,7 @@ content:
     region: content
   field_landing_page_component:
     type: paragraphs
-    weight: 24
+    weight: 25
     region: content
     settings:
       title: Component

--- a/config/install/core.entity_form_display.node.publication.default.yml
+++ b/config/install/core.entity_form_display.node.publication.default.yml
@@ -10,6 +10,7 @@ dependencies:
     - field.field.node.publication.field_landing_page_show_contact
     - field.field.node.publication.field_landing_page_summary
     - field.field.node.publication.field_license_type
+    - field.field.node.publication.field_node_display_headings
     - field.field.node.publication.field_node_documents
     - field.field.node.publication.field_publication_authors
     - field.field.node.publication.field_publication_date
@@ -69,6 +70,7 @@ third_party_settings:
     group_body_content:
       children:
         - field_show_table_of_content
+        - field_node_display_headings
         - field_landing_page_component
         - field_node_documents
       parent_name: group_section_1
@@ -244,6 +246,12 @@ content:
     settings: {  }
     third_party_settings: {  }
     type: options_select
+    region: content
+  field_node_display_headings:
+    weight: 24
+    settings: {  }
+    third_party_settings: {  }
+    type: options_buttons
     region: content
   field_node_documents:
     weight: 25

--- a/config/install/core.entity_form_display.node.publication_page.default.yml
+++ b/config/install/core.entity_form_display.node.publication_page.default.yml
@@ -158,7 +158,7 @@ content:
     third_party_settings: {  }
   field_landing_page_component:
     type: paragraphs
-    weight: 24
+    weight: 25
     region: content
     settings:
       title: Component

--- a/config/install/core.entity_form_display.node.publication_page.default.yml
+++ b/config/install/core.entity_form_display.node.publication_page.default.yml
@@ -7,6 +7,7 @@ dependencies:
     - field.field.node.publication_page.field_landing_page_intro_text
     - field.field.node.publication_page.field_landing_page_show_contact
     - field.field.node.publication_page.field_landing_page_summary
+    - field.field.node.publication_page.field_node_display_headings
     - field.field.node.publication_page.field_publication
     - field.field.node.publication_page.field_related_links
     - field.field.node.publication_page.field_show_content_rating
@@ -131,6 +132,7 @@ third_party_settings:
     group_body_content:
       children:
         - field_show_table_of_content
+        - field_node_display_headings
         - field_landing_page_component
       parent_name: group_section_1
       weight: 3
@@ -211,6 +213,12 @@ content:
         maxlength_js_enforce: false
         maxlength_js_truncate_html: false
     type: string_textarea
+    region: content
+  field_node_display_headings:
+    weight: 24
+    settings: {  }
+    third_party_settings: {  }
+    type: options_buttons
     region: content
   field_publication:
     weight: 7

--- a/config/install/field.field.node.publication.field_node_display_headings.yml
+++ b/config/install/field.field.node.publication.field_node_display_headings.yml
@@ -1,0 +1,22 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_node_display_headings
+    - node.type.publication
+  module:
+    - options
+id: node.publication.field_node_display_headings
+field_name: field_node_display_headings
+entity_type: node
+bundle: publication
+label: 'Display headings'
+description: ''
+required: true
+translatable: true
+default_value:
+  -
+    value: showH2
+default_value_callback: ''
+settings: {  }
+field_type: list_string

--- a/config/install/field.field.node.publication.field_show_table_of_content.yml
+++ b/config/install/field.field.node.publication.field_show_table_of_content.yml
@@ -9,7 +9,7 @@ field_name: field_show_table_of_content
 entity_type: node
 bundle: publication
 label: 'Show Table of Content?'
-description: 'Check this box if you want to show the Table of Content on this page.'
+description: 'The table of contents is automatically built from the heading structure of your page.'
 required: false
 translatable: true
 default_value:

--- a/config/install/field.field.node.publication_page.field_node_display_headings.yml
+++ b/config/install/field.field.node.publication_page.field_node_display_headings.yml
@@ -1,0 +1,22 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_node_display_headings
+    - node.type.publication_page
+  module:
+    - options
+id: node.publication_page.field_node_display_headings
+field_name: field_node_display_headings
+entity_type: node
+bundle: publication_page
+label: 'Display headings'
+description: ''
+required: true
+translatable: true
+default_value:
+  -
+    value: showH2
+default_value_callback: ''
+settings: {  }
+field_type: list_string

--- a/config/install/field.field.node.publication_page.field_show_table_of_content.yml
+++ b/config/install/field.field.node.publication_page.field_show_table_of_content.yml
@@ -9,7 +9,7 @@ field_name: field_show_table_of_content
 entity_type: node
 bundle: publication_page
 label: 'Show Table of Content?'
-description: 'Check this box if you want to show the Table of Content on this page.'
+description: 'The table of contents is automatically built from the heading structure of your page.'
 required: false
 translatable: true
 default_value:

--- a/config/optional/jsonapi_extras.jsonapi_resource_config.node--publication.yml
+++ b/config/optional/jsonapi_extras.jsonapi_resource_config.node--publication.yml
@@ -192,6 +192,12 @@ resourceFields:
     enhancer:
       id: ''
     disabled: false
+  field_node_display_headings:
+    fieldName: field_node_display_headings
+    publicName: field_node_display_headings
+    enhancer:
+      id: ''
+    disabled: false
   field_node_documents:
     fieldName: field_node_documents
     publicName: field_node_documents

--- a/config/optional/jsonapi_extras.jsonapi_resource_config.node--publication_page.yml
+++ b/config/optional/jsonapi_extras.jsonapi_resource_config.node--publication_page.yml
@@ -174,6 +174,12 @@ resourceFields:
     enhancer:
       id: ''
     disabled: false
+  field_node_display_headings:
+    fieldName: field_node_display_headings
+    publicName: field_node_display_headings
+    enhancer:
+      id: ''
+    disabled: false
   field_node_primary_site:
     fieldName: field_node_primary_site
     publicName: field_node_primary_site

--- a/tests/behat/features/fields.feature
+++ b/tests/behat/features/fields.feature
@@ -1,4 +1,4 @@
-@tide
+@tide @test-me
 Feature: Fields for Publication content type
 
   Ensure that Publication content has the expected fields.
@@ -38,6 +38,11 @@ Feature: Fields for Publication content type
     Then I press "Documents"
     Then I should see an "#edit-field-node-documents" element
     And I should see an "input#edit-field-node-documents-entity-browser-entity-browser-open-modal" element
+
+    When I check "edit-field-show-table-of-content-value"
+    Then I should see text matching "Display headings"
+    And I should see an "input#edit-field-node-display-headings-showh2" element
+    And I should see an "input#edit-field-node-display-headings-showh2andh3" element
 
     And I see field "Show Publication Navigation?"
     And I should see an "input#edit-field-show-publication-nav-value" element
@@ -117,6 +122,11 @@ Feature: Fields for Publication content type
     And I should see an "input#edit-field-show-table-of-content-value" element
     And I should not see an "input#edit-field-show-table-of-content.required" element
 
+    When I check "edit-field-show-table-of-content-value"
+    Then I should see text matching "Display headings"
+    And I should see an "input#edit-field-node-display-headings-showh2" element
+    And I should see an "input#edit-field-node-display-headings-showh2andh3" element
+
     And I should see text matching "Content components"
     And I should see "Basic Text" in the "select[name='field_landing_page_component[add_more][add_more_select]']" element
     And I should see "Accordion" in the "select[name='field_landing_page_component[add_more][add_more_select]']" element
@@ -130,7 +140,7 @@ Feature: Fields for Publication content type
     And I should see "Key dates" in the "select[name='field_landing_page_component[add_more][add_more_select]']" element
     And I should see "Timelines" in the "select[name='field_landing_page_component[add_more][add_more_select]']" element
     And I should see "Complex Image" in the "select[name='field_landing_page_component[add_more][add_more_select]']" element
-    And I should see "Embedded Webform" in the "select[name='field_landing_page_component[add_more][add_more_select]']" element
+    And I should see "Form embed (Drupal)" in the "select[name='field_landing_page_component[add_more][add_more_select]']" element
     And I should see "Featured news" in the "select[name='field_landing_page_component[add_more][add_more_select]']" element
 
     And I see field "Show Content Rating?"

--- a/tide_publication.info.yml
+++ b/tide_publication.info.yml
@@ -26,6 +26,7 @@ config_devel:
     - field.field.node.publication.field_landing_page_intro_text
     - field.field.node.publication.field_landing_page_show_contact
     - field.field.node.publication.field_landing_page_summary
+    - field.field.node.publication_page.field_node_display_headings
     - field.field.node.publication.field_license_type
     - field.field.node.publication.field_node_documents
     - field.field.node.publication.field_publication_authors

--- a/tide_publication.install
+++ b/tide_publication.install
@@ -151,7 +151,7 @@ function _tide_publication_update_search_api_index() {
  */
 function tide_publication_update_dependencies() {
   $dependencies['tide_publication'][8001] = ['tide_landing_page' => 8008];
-  $dependencies['tide_publication'][8009] = ['tide_core' => 8036];
+  $dependencies['tide_publication'][8009] = ['tide_core' => 8037];
 
   return $dependencies;
 }

--- a/tide_publication.install
+++ b/tide_publication.install
@@ -484,7 +484,7 @@ function tide_publication_update_8009() {
       ];
       $json_config->set('resourceFields', $json_content);
     }
-    $config->save();
+    $json_config->save();
   }
   // Update show table of content label.
   $fields = [

--- a/tide_publication.install
+++ b/tide_publication.install
@@ -151,6 +151,7 @@ function _tide_publication_update_search_api_index() {
  */
 function tide_publication_update_dependencies() {
   $dependencies['tide_publication'][8001] = ['tide_landing_page' => 8008];
+  $dependencies['tide_publication'][8009] = ['tide_core' => 8036];
 
   return $dependencies;
 }
@@ -459,6 +460,9 @@ function tide_publication_update_8009() {
       ];
       $config->set('content', $content);
     }
+    // Increase weight to sit below the new field.
+    $landing_page_component = $config->get('content.field_landing_page_component.weight');
+    $config->set('content.field_landing_page_component.weight', $landing_page_component + 1);
     $config->save();
   }
   // Add Json.

--- a/tide_publication.install
+++ b/tide_publication.install
@@ -400,3 +400,97 @@ function tide_publication_update_8008() {
     }
   }
 }
+
+/**
+ * Add field display headings for table of contents.
+ */
+function tide_publication_update_8009() {
+  module_load_include('inc', 'tide_core', 'includes/helpers');
+  $config_location = [drupal_get_path('module', 'tide_page') . '/config/install'];
+  $new_fields = [
+    'field.field.node.publication_page.field_node_display_headings',
+    'field.field.node.publication.field_node_display_headings',
+  ];
+  foreach ($new_fields as $new_field) {
+    $config_read = _tide_read_config($new_field, $config_location, TRUE);
+    // Obtain the storage manager for field instances.
+    // Create a new field instance from the yaml configuration and save.
+    \Drupal::entityManager()->getStorage('field_config')
+      ->create($config_read)
+      ->save();
+  }
+  $config_factory = \Drupal::configFactory();
+  // Add to form display.
+  $new_displayss = [
+    'core.entity_form_display.node.publication_page.default' => 'field.field.node.publication_page.field_node_display_headings',
+    'core.entity_form_display.node.publication.default' => 'field.field.node.publication.field_node_display_headings',
+  ];
+  foreach ($new_displayss as $display => $field) {
+    $config = $config_factory->getEditable($display);
+
+    $dependencies = $config->get('dependencies.config');
+    if (!in_array($field, $dependencies)) {
+      $dependencies[] = $field;
+      $config->set('dependencies.config', $dependencies);
+    }
+    $group_body_content = 'third_party_settings.field_group.group_body_content.children';
+    $third_party_settings = $config->get($group_body_content);
+    if (!isset($third_party_settings['field_node_display_headings'])) {
+      $third_party_settings = [
+        'field_show_table_of_content',
+        'field_node_display_headings',
+        'field_landing_page_component',
+      ];
+      $config->set($group_body_content, $third_party_settings);
+      if ($display == 'core.entity_form_display.node.publication.default') {
+        $third_party_settings[] = 'field_node_documents';
+        $config->set($group_body_content, $third_party_settings);
+      }
+    }
+    $table_of_content_weight = $config->get('content.field_show_table_of_content.weight');
+    $content = $config->get('content');
+    if (!isset($content['field_node_display_headings'])) {
+      $content['field_node_display_headings'] = [
+        'weight' => $table_of_content_weight + 1,
+        'settings' => [],
+        'third_party_settings' => [],
+        'type' => 'options_buttons',
+        'region' => 'content',
+      ];
+      $config->set('content', $content);
+    }
+    $config->save();
+  }
+  // Add Json.
+  $json_feilds = [
+    'jsonapi_extras.jsonapi_resource_config.node--publication_page',
+    'jsonapi_extras.jsonapi_resource_config.node--publication',
+  ];
+  foreach ($json_feilds as $field) {
+    $json_config = $config_factory->getEditable($field);
+    $json_content = $json_config->get('resourceFields');
+    if (!isset($json_content['field_node_display_headings'])) {
+      $json_content['field_node_display_headings'] = [
+        'fieldName' => 'field_node_display_headings',
+        'publicName' => 'field_node_display_headings',
+        'enhancer' => [
+          'id' => '',
+        ],
+        'disabled' => FALSE,
+      ];
+      $json_config->set('resourceFields', $json_content);
+    }
+    $config->save();
+  }
+  // Update show table of content label.
+  $fields = [
+    'field.field.node.publication_page.field_show_table_of_content',
+    'field.field.node.publication.field_show_table_of_content',
+  ];
+  foreach ($fields as $field) {
+    $field_config = $config_factory->getEditable($field);
+    $description = 'The table of contents is automatically built from the heading structure of your page.';
+    $field_config->set('description', $description);
+    $field_config->save();
+  }
+}

--- a/tide_publication.install
+++ b/tide_publication.install
@@ -406,7 +406,7 @@ function tide_publication_update_8008() {
  */
 function tide_publication_update_8009() {
   module_load_include('inc', 'tide_core', 'includes/helpers');
-  $config_location = [drupal_get_path('module', 'tide_page') . '/config/install'];
+  $config_location = [drupal_get_path('module', 'tide_publication') . '/config/install'];
   $new_fields = [
     'field.field.node.publication_page.field_node_display_headings',
     'field.field.node.publication.field_node_display_headings',

--- a/tide_publication.module
+++ b/tide_publication.module
@@ -105,7 +105,7 @@ function tide_publication_form_node_form_alter(&$form, FormStateInterface $form_
       $form['field_node_display_headings']['#states'] = [
         'visible' => [
           ':input[name="field_show_table_of_content[value]"]' => [
-            'checked' => TRUE
+            'checked' => TRUE,
           ],
         ],
       ];

--- a/tide_publication.module
+++ b/tide_publication.module
@@ -100,6 +100,16 @@ function tide_publication_form_node_form_alter(&$form, FormStateInterface $form_
   if (in_array($form_id, $publication_forms)) {
     // Change form layout.
     $form['#attached']['library'][] = 'tide_landing_page/landing_page_form';
+    // Add conditional field for show table of content.
+    if (isset($form['field_node_display_headings'])) {
+      $form['field_node_display_headings']['#states'] = [
+        'visible' => [
+          ':input[name="field_show_table_of_content[value]"]' => [
+            'checked' => TRUE
+          ],
+        ],
+      ];
+    }
   }
 }
 


### PR DESCRIPTION
### Jira
https://digital-engagement.atlassian.net/browse/SDPA-4582

### Change
1. Added new field instance for the header radio button (Which will be used to show H2 or H2 and H3 for table of contents.) on and update hook.
2. Update entity form display and Json resource.
3. Updated help text for "show table of contents" checkbox.
4. Added conditional filed logic in node_form_alter to show the new field only when the "show table of contents" checkbox is checked.
5. Added behat test.

### Related PR
Field storage added in tide_core - https://github.com/dpc-sdp/tide_core/pull/175
https://github.com/dpc-sdp/tide_landing_page/pull/106
https://github.com/dpc-sdp/tide_page/pull/23

### Test branch on content-vic
https://github.com/dpc-sdp/content-vic-gov-au/pull/963