### PR TITLE
[SDPAP-9178] Removed jsonapi access check.

### DIFF
--- a/src/Controller/PublicationResource.php
+++ b/src/Controller/PublicationResource.php
@@ -13,7 +13,6 @@ use Drupal\entity_hierarchy\Storage\NestedSetNodeKeyFactory;
 use Drupal\entity_hierarchy\Storage\NestedSetStorage;
 use Drupal\entity_hierarchy\Storage\NestedSetStorageFactory;
 use Drupal\jsonapi\Controller\EntityResource;
-use Drupal\jsonapi\Exception\EntityAccessDeniedHttpException;
 use Drupal\jsonapi\JsonApiResource\Link;
 use Drupal\jsonapi\JsonApiResource\LinkCollection;
 use Drupal\jsonapi\Routing\Routes;
@@ -96,9 +95,6 @@ class PublicationResource extends EntityResource {
    *
    * @return \Drupal\jsonapi\ResourceResponse|\Symfony\Component\HttpFoundation\JsonResponse
    *   The response.
-   *
-   * @throws \Drupal\jsonapi\Exception\EntityAccessDeniedHttpException|\Exception
-   *   Thrown when access to the entity is not allowed.
    */
   public function getHierarchy(EntityInterface $entity, Request $request) {
     if (!($entity instanceof ContentEntityInterface)) {
@@ -106,10 +102,6 @@ class PublicationResource extends EntityResource {
     }
 
     $resource_object = $this->entityAccessChecker->getAccessCheckedResourceObject($entity);
-    if ($resource_object instanceof EntityAccessDeniedHttpException) {
-      throw $resource_object;
-    }
-
     if ($entity->bundle() != 'publication') {
       $response = $this->buildWrappedResponse($resource_object, $request, $this->getIncludes($request, $resource_object));
       return $response;


### PR DESCRIPTION
### Issue
This check is blocking access to the JSON API for the share link. Somehow, Ripple 1 used to bypass this check even though access was blocked. However, Ripple 2 catches this and ends up not showing the share link for the publication. The access check already occurs beforehand when validating the share link token. Additionally, drafts are not visible in the frontend without the assistance of the share link. Therefore, this extra check seems unnecessary.

### Changes 
Removed JSON API exception check for publication hierarchy method.

 